### PR TITLE
Fix poor low-speed driving — cogging & wheel stalls in closed-loop velocity control (#10)

### DIFF
--- a/ROS_Driver/movtion_module.h
+++ b/ROS_Driver/movtion_module.h
@@ -126,11 +126,22 @@ ESP32Encoder encoderB;
 static unsigned long lastTime = 0;
 static unsigned long lastLeftSpdTime = 0;
 static unsigned long lastRightSpdTime = 0;
-int lastEncoderA = 0;
-int lastEncoderB = 0;
+int64_t lastEncoderA = 0;
+int64_t lastEncoderB = 0;
 
 double speedGetA;
 double speedGetB;
+
+// Sample encoder velocity over a fixed interval and hold the last estimate
+// between samples. Measuring every cooperative-loop tick makes the denominator
+// tiny and pulse quantisation dominates; returning zero until a pulse threshold
+// is reached makes the high-I PID over-ramp. A 50 ms sample gives about
+// 13 pulses at 0.1 m/s on the UGV Rover, which is enough to damp cogging
+// without adding much control latency.
+const unsigned long SPEED_SAMPLE_INTERVAL_US = 50000;
+const double SPEED_FILTER_ALPHA = 0.3;
+double speedFilteredA = 0;
+double speedFilteredB = 0;
 
 double plusesRate = 3.14159265359 * WHEEL_D / ONE_CIRCLE_PLUSES;
 
@@ -140,34 +151,91 @@ void initEncoders() {
   encoderB.attachHalfQuad(BENCA, BENCB);
   encoderA.setCount(0);
   encoderB.setCount(0);
+  unsigned long currentTime = micros();
+  lastEncoderA = encoderA.getCount();
+  lastEncoderB = encoderB.getCount();
+  lastLeftSpdTime = currentTime;
+  lastRightSpdTime = currentTime;
+  speedGetA = 0;
+  speedGetB = 0;
+  speedFilteredA = 0;
+  speedFilteredB = 0;
+}
+
+void resetLeftSpeedEstimate() {
+  lastEncoderA = encoderA.getCount();
+  lastLeftSpdTime = micros();
+  speedGetA = 0;
+  speedFilteredA = 0;
+}
+
+void resetRightSpeedEstimate() {
+  lastEncoderB = encoderB.getCount();
+  lastRightSpdTime = micros();
+  speedGetB = 0;
+  speedFilteredB = 0;
 }
 
 void getLeftSpeed() {
   unsigned long currentTime = micros();
-  long encoderPulsesA = encoderA.getCount();
+  int64_t encoderPulsesA = encoderA.getCount();
+
+  // Odometry from absolute count (unchanged behaviour)
   if (!SET_MOTOR_DIR) {
-    speedGetA = (plusesRate * (encoderPulsesA - lastEncoderA)) / ((double)(currentTime - lastLeftSpdTime) / 1000000);
     en_odom_l = ((float)encoderPulsesA / ONE_CIRCLE_PLUSES) * WHEEL_D * 3.14159265359;
   } else {
-    speedGetA = (plusesRate * (lastEncoderA - encoderPulsesA)) / ((double)(currentTime - lastLeftSpdTime) / 1000000);
     en_odom_l = - ((float)encoderPulsesA / ONE_CIRCLE_PLUSES) * WHEEL_D * 3.14159265359;
   }
+
+  unsigned long elapsed = currentTime - lastLeftSpdTime;
+  if (elapsed < SPEED_SAMPLE_INTERVAL_US) {
+    return;
+  }
+
+  int64_t pulseDelta;
+  if (!SET_MOTOR_DIR) {
+    pulseDelta = encoderPulsesA - lastEncoderA;
+  } else {
+    pulseDelta = lastEncoderA - encoderPulsesA;
+  }
+
+  const double measuredSpeedA = (plusesRate * pulseDelta) / ((double)elapsed / 1000000);
   lastEncoderA = encoderPulsesA;
   lastLeftSpdTime = currentTime;
+
+  speedFilteredA = SPEED_FILTER_ALPHA * measuredSpeedA + (1.0 - SPEED_FILTER_ALPHA) * speedFilteredA;
+  speedGetA = speedFilteredA;  // control + T1001 feedback share the EMA-smoothed velocity (addresses #10)
 }
 
 void getRightSpeed() {
   unsigned long currentTime = micros();
-  long encoderPulsesB = encoderB.getCount();
+  int64_t encoderPulsesB = encoderB.getCount();
+
+  // Odometry from absolute count (unchanged behaviour)
   if (!SET_MOTOR_DIR) {
-    speedGetB = (plusesRate * (encoderPulsesB - lastEncoderB)) / ((double)(currentTime - lastRightSpdTime) / 1000000);
     en_odom_r = ((float)encoderPulsesB / ONE_CIRCLE_PLUSES) * WHEEL_D * 3.14159265359;
   } else {
-    speedGetB = (plusesRate * (lastEncoderB - encoderPulsesB)) / ((double)(currentTime - lastRightSpdTime) / 1000000);
     en_odom_r = - ((float)encoderPulsesB / ONE_CIRCLE_PLUSES) * WHEEL_D * 3.14159265359;
   }
+
+  unsigned long elapsed = currentTime - lastRightSpdTime;
+  if (elapsed < SPEED_SAMPLE_INTERVAL_US) {
+    return;
+  }
+
+  int64_t pulseDelta;
+  if (!SET_MOTOR_DIR) {
+    pulseDelta = encoderPulsesB - lastEncoderB;
+  } else {
+    pulseDelta = lastEncoderB - encoderPulsesB;
+  }
+
+  const double measuredSpeedB = (plusesRate * pulseDelta) / ((double)elapsed / 1000000);
   lastEncoderB = encoderPulsesB;
   lastRightSpdTime = currentTime;
+
+  speedFilteredB = SPEED_FILTER_ALPHA * measuredSpeedB + (1.0 - SPEED_FILTER_ALPHA) * speedFilteredB;
+  speedGetB = speedFilteredB;  // control + T1001 feedback share the EMA-smoothed velocity (addresses #10)
 }
 
 
@@ -197,12 +265,14 @@ void pidControllerInit() {
              outputA,
              setpointA);
   pidA.SetOutputLimits(-255, 255);
+  pidA.SetSampleTime(50);
   pidA.SetMode(PID::Automatic);
 
   pidB.Start(speedGetB,
              outputB,
              setpointB);
   pidB.SetOutputLimits(-255, 255);
+  pidB.SetSampleTime(50);
   pidB.SetMode(PID::Automatic);
 }
 
@@ -260,6 +330,26 @@ void rightCtrl(float pwmInputB){
   }
 }
 
+double motorFeedForward(double setpoint) {
+  if (setpoint == 0) {
+    return 0;
+  }
+
+  double direction = setpoint > 0 ? 1.0 : -1.0;
+  double magnitude = MOTOR_MIN_FEEDFORWARD_PWM + (abs(setpoint) * MOTOR_SPEED_FEEDFORWARD_PWM);
+  return direction * magnitude;
+}
+
+double clampMotorOutput(double output) {
+  if (output > 255) {
+    return 255;
+  }
+  if (output < -255) {
+    return -255;
+  }
+  return output;
+}
+
 void setGoalSpeed(float inputLeft, float inputRight) {
   usePIDCompute = true;
 
@@ -271,17 +361,27 @@ void setGoalSpeed(float inputLeft, float inputRight) {
     return;
   }
   
-  setpointA = inputLeft*spd_rate_A;
-  setpointB = inputRight*spd_rate_B;
+  double nextSetpointA = inputLeft*spd_rate_A;
+  double nextSetpointB = inputRight*spd_rate_B;
+
+  if (nextSetpointA == 0 || (setpointA < 0 && nextSetpointA > 0) || (setpointA > 0 && nextSetpointA < 0)) {
+    resetLeftSpeedEstimate();
+  }
+  if (nextSetpointB == 0 || (setpointB < 0 && nextSetpointB > 0) || (setpointB > 0 && nextSetpointB < 0)) {
+    resetRightSpeedEstimate();
+  }
+
+  setpointA = nextSetpointA;
+  setpointB = nextSetpointB;
 
   if (setpointA != setpointA_buffer) {
     pidA.Setpoint(setpointA);
-    setpointA_buffer = inputLeft;
+    setpointA_buffer = setpointA;
   }
-  
+
   if (setpointB != setpointB_buffer) {
     pidB.Setpoint(setpointB);
-    setpointB_buffer = inputRight;
+    setpointB_buffer = setpointB;
   }
 }
 
@@ -290,12 +390,11 @@ void LeftPidControllerCompute() {
     return;
   }
 
-  outputA = pidA.Run(speedGetA);
-  if (abs(outputA)<THRESHOLD_PWM) {
+  double pidOutput = pidA.Run(speedFilteredA);
+  if (setpointA == 0) {
     outputA = 0;
-  }
-  if (setpointA == 0 && speedGetA == 0) {
-    outputA = 0;
+  } else {
+    outputA = clampMotorOutput(motorFeedForward(setpointA) + pidOutput);
   }
   leftCtrl(outputA);
 }
@@ -305,12 +404,11 @@ void RightPidControllerCompute() {
     return;
   }
 
-  outputB = pidB.Run(speedGetB);
-  if (abs(outputB)<THRESHOLD_PWM) {
+  double pidOutput = pidB.Run(speedFilteredB);
+  if (setpointB == 0) {
     outputB = 0;
-  }
-  if (setpointB == 0 && speedGetB == 0) {
-    outputB = 0;
+  } else {
+    outputB = clampMotorOutput(motorFeedForward(setpointB) + pidOutput);
   }
   rightCtrl(outputB);
 }
@@ -325,9 +423,16 @@ void setPID(float inputP, float inputI, float inputD, float inputLimits) {
 }
 
 void rosCtrl(float rosX, float rosZ) {
-  setpointA = rosX - (rosZ * TRACK_WIDTH / 2.0);
-  setpointB = rosX + (rosZ * TRACK_WIDTH / 2.0);
-  setGoalSpeed(setpointA, setpointB);
+  // Pass locals into setGoalSpeed so its stop/reversal reset can compare the new
+  // command against the PREVIOUS setpointA/setpointB before they're overwritten.
+  double localA = rosX - (rosZ * TRACK_WIDTH / 2.0);
+  double localB = rosX + (rosZ * TRACK_WIDTH / 2.0);
+  // Snap float residue to exactly zero at the source: a wheel that should cancel
+  // to zero must not reach motorFeedForward() as a tiny non-zero (which would
+  // kick it to MOTOR_MIN_FEEDFORWARD_PWM and twitch a wheel meant to be still).
+  if (fabs(localA) < 1e-4) localA = 0;
+  if (fabs(localB) < 1e-4) localB = 0;
+  setGoalSpeed(localA, localB);
 }
 
 void heartBeatCtrl() {

--- a/ROS_Driver/uart_ctrl.h
+++ b/ROS_Driver/uart_ctrl.h
@@ -24,9 +24,17 @@ void jsonCmdReceiveHandler(){
 												leftCtrl(jsonCmdReceive["L"]);
 												rightCtrl(jsonCmdReceive["R"]);
 												break;
-	case CMD_ROS_CTRL:		rosCtrl(
+	case CMD_ROS_CTRL:		if (jsonCmdReceive.containsKey("X") &&
+												jsonCmdReceive.containsKey("Z")){
+												if (jsonCmdReceive["X"].is<float>() &&
+												jsonCmdReceive["Z"].is<float>()){
+												heartbeatStopFlag = false;
+												lastCmdRecvTime = millis();
+												rosCtrl(
 												jsonCmdReceive["X"],
-												jsonCmdReceive["Z"]);break;
+												jsonCmdReceive["Z"]);
+												}
+												} break;
 	case CMD_SET_MOTOR_PID:
 												setPID(
 												jsonCmdReceive["P"],

--- a/ROS_Driver/ugv_config.h
+++ b/ROS_Driver/ugv_config.h
@@ -313,7 +313,7 @@ String jsonFeedbackWeb = "";
 //  --- --- --- pid controller --- --- ---
 
 float __kp = 20.0;
-float __ki = 2000.0;
+float __ki = 120.0;
 float __kd = 0;
 float windup_limits = 255;
 
@@ -321,6 +321,9 @@ float windup_limits = 255;
 //  --- --- --- ugv base --- --- ---
 
 #define THRESHOLD_PWM 23
+
+const double MOTOR_MIN_FEEDFORWARD_PWM = 34.0;
+const double MOTOR_SPEED_FEEDFORWARD_PWM = 60.0;
 
 // mainType:01 RaspRover
 // #define WHEEL_D 0.0800


### PR DESCRIPTION
Fixes #10.

Closed-loop wheel velocity control (`T:1` / ROS `cmd_vel`) drives poorly at low speed — the rover cogs, stalls a wheel, and lurches instead of holding a smooth commanded velocity.

## Root causes

1. **Per-tick velocity quantisation** — speed was computed from the encoder delta on every cooperative-loop iteration; the time base is tiny, so at low speed each sample sees only 0–1 pulses and the estimate is a noisy square wave rather than a usable signal.
2. **Integral wind-up** — `__ki = 2000` against that noisy feedback overshoots and oscillates.
3. **Deadband zeroing** — `if (abs(output) < THRESHOLD_PWM) output = 0;` cut any low output to zero, repeatedly stalling a wheel at low speed.

## The fix (`movtion_module.h`, `ugv_config.h`)

- Fixed **50 ms velocity sampling + EMA**; the same smoothed value feeds both the PID and the `T:1001` velocity feedback.
- **`__ki` 2000 → 120** to stop wind-up against the now-clean feedback.
- **Static feed-forward** (`MOTOR_MIN_FEEDFORWARD_PWM + |setpoint| · MOTOR_SPEED_FEEDFORWARD_PWM`) clears static friction without the PID having to wind up — replacing the THRESHOLD_PWM deadband-zeroing.
- **`pid.SetSampleTime(50)`** matched to the new feedback rate.
- **Speed-estimate reset** on stop / direction reversal, so a stale value doesn't kick the controller on the next command.
- `int64_t` encoder counters to match `ESP32Encoder::getCount()`.
- Validate `X`/`Z` in `CMD_ROS_CTRL` before refreshing the watchdog (`uart_ctrl.h`).

## Testing

Flashed and field-tested on a UGV Rover (ESP32). Low-speed straight-line and rotate-in-place driving are smooth; the per-wheel stalls are gone. Compiles clean against esp32 arduino core 3.1.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
